### PR TITLE
Relax root requirement for help/completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ sudo uupd
 # CLI Options
 
 ```
-  $ sudo uupd --help
+  $ uupd --help
 ```
 
 # Troubleshooting

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,38 +2,56 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"github.com/spf13/cobra"
 	"os"
+	"os/user"
 )
+
+func assertRoot(cmd *cobra.Command, args []string) {
+	currentUser, err := user.Current()
+
+	if err != nil {
+		log.Fatalf("Error fetching current user: %v", err)
+	}
+	if currentUser.Uid != "0" {
+		log.Fatalf("uupd needs to be invoked as root.")
+	}
+}
 
 var (
 	rootCmd = &cobra.Command{
 		Use:   "uupd",
 		Short: "uupd (Universal Update) is the successor to ublue-update, built for bootc",
+		PreRun: assertRoot,
 		Run:   Update,
 	}
 
 	waitCmd = &cobra.Command{
 		Use:   "wait",
 		Short: "Waits for ostree sysroot to unlock",
+		PreRun: assertRoot,
 		Run:   Wait,
 	}
 
 	updateCheckCmd = &cobra.Command{
 		Use:   "update-check",
 		Short: "Check for updates to the booted image",
+		PreRun: assertRoot,
 		Run:   UpdateCheck,
 	}
 
 	hardwareCheckCmd = &cobra.Command{
 		Use:   "hw-check",
 		Short: "Run hardware checks",
+		PreRun: assertRoot,
 		Run:   HwCheck,
 	}
 
 	imageOutdatedCmd = &cobra.Command{
 		Use:   "is-img-outdated",
 		Short: "Print 'true' or 'false' based on if the current booted image is over 1 month old",
+		PreRun: assertRoot,
 		Run:   ImageOutdated,
 	}
 )

--- a/main.go
+++ b/main.go
@@ -3,17 +3,9 @@ package main
 import (
 	"github.com/ublue-os/uupd/cmd"
 	"log"
-	"os/user"
 )
 
 func main() {
 	log.SetFlags(0)
-	currentUser, err := user.Current()
-	if err != nil {
-		log.Fatalf("Error fetching current user: %v", err)
-	}
-	if currentUser.Uid != "0" {
-		log.Fatalf("uupd needs to be invoked as root.")
-	}
 	cmd.Execute()
 }


### PR DESCRIPTION
Fixes #7. It is now possible to call `uupd --help`, `uupd help` and `uupd completion` without being root.