### PR TITLE
fix: make distrobox automatically disable, fix versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ sudo uupd
 # CLI Options
 
 ```
-  $ uupd --help
+$ uupd --help
 ```
 
 # Troubleshooting

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	appLogging "github.com/ublue-os/uupd/pkg/logging"
+	"golang.org/x/term"
 )
 
 func assertRoot(cmd *cobra.Command, args []string) {
@@ -111,7 +112,8 @@ func init() {
 	rootCmd.Flags().BoolP("dry-run", "n", false, "Do a dry run")
 	rootCmd.Flags().BoolP("verbose", "v", false, "Display command outputs after run")
 	rootCmd.Flags().Bool("ci", false, "Makes some modifications to behavior if is running in CI")
-
+	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
+	rootCmd.Flags().Bool("disable-osc-progress", !isTerminal, "Disable the GUI progress indicator")
 	rootCmd.PersistentFlags().BoolVar(&fLogJson, "json", false, "Print logs as json (used for testing)")
 	rootCmd.PersistentFlags().StringVar(&fLogFile, "log-file", "-", "File where user-facing logs will be written to")
 	rootCmd.PersistentFlags().StringVar(&fLogLevel, "log-level", "info", "Log level for user-facing logs")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -117,7 +117,7 @@ func Update(cmd *cobra.Command, args []string) {
 	}
 
 	// -1 because 0 index
-	tracker := &percent.Incrementer{MaxIncrements: totalSteps - 1}
+	tracker := &percent.Incrementer{MaxIncrements: totalSteps - 1, OscEnabled: !disableOsc}
 
 	flatpakUpdater.Tracker = tracker
 	distroboxUpdater.Tracker = tracker
@@ -144,7 +144,7 @@ func Update(cmd *cobra.Command, args []string) {
 
 	if mainSystemDriverConfig.Enabled {
 		slog.Debug(fmt.Sprintf("%s module", mainSystemDriverConfig.Title), slog.String("module_name", mainSystemDriverConfig.Title), slog.Any("module_configuration", mainSystemDriverConfig))
-		percent.ReportStatusChange(tracker, percent.TrackerMessage{Title: mainSystemDriverConfig.Title, Description: mainSystemDriverConfig.Description})
+		tracker.ReportStatusChange(mainSystemDriverConfig.Title, mainSystemDriverConfig.Description)
 		var out *[]drv.CommandOutput
 		out, err = mainSystemDriver.Update()
 		outputs = append(outputs, *out...)
@@ -153,7 +153,7 @@ func Update(cmd *cobra.Command, args []string) {
 
 	if brewUpdater.Config.Enabled {
 		slog.Debug(fmt.Sprintf("%s module", brewUpdater.Config.Title), slog.String("module_name", brewUpdater.Config.Title), slog.Any("module_configuration", brewUpdater.Config))
-		percent.ReportStatusChange(tracker, percent.TrackerMessage{Title: brewUpdater.Config.Title, Description: brewUpdater.Config.Description})
+		tracker.ReportStatusChange(brewUpdater.Config.Title, brewUpdater.Config.Description)
 		var out *[]drv.CommandOutput
 		out, err = brewUpdater.Update()
 		outputs = append(outputs, *out...)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -98,8 +98,10 @@ func Update(cmd *cobra.Command, args []string) {
 		totalSteps += mainSystemDriver.Steps()
 	}
 
-	// FIXME: check if is interactive
-	percent.ResetOscProgress()
+	disableOsc, err := cmd.Flags().GetBool("disable-osc-progress")
+	if !disableOsc {
+		percent.ResetOscProgress()
+	}
 
 	// -1 because 0 index
 	tracker := &percent.Incrementer{MaxIncrements: totalSteps - 1}
@@ -161,8 +163,9 @@ func Update(cmd *cobra.Command, args []string) {
 		tracker.IncrementSection(err)
 	}
 
-	// FIXME: detect interactive session
-	percent.ResetOscProgress()
+	if !disableOsc {
+		percent.ResetOscProgress()
+	}
 	if verboseRun {
 		slog.Info("Verbose run requested")
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -50,6 +50,11 @@ func Update(cmd *cobra.Command, args []string) {
 		slog.Error("Failed to get verbose flag", "error", err)
 		return
 	}
+	disableOsc, err := cmd.Flags().GetBool("disable-osc-progress")
+	if err != nil {
+		slog.Error("Failed to get disable-osc-progress flag", "error", err)
+		return
+	}
 
 	if hwCheck {
 		err := checks.RunHwChecks()
@@ -98,7 +103,6 @@ func Update(cmd *cobra.Command, args []string) {
 		totalSteps += mainSystemDriver.Steps()
 	}
 
-	disableOsc, err := cmd.Flags().GetBool("disable-osc-progress")
 	if !disableOsc {
 		percent.ResetOscProgress()
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -78,14 +78,23 @@ func Update(cmd *cobra.Command, args []string) {
 	initConfiguration.Verbose = verboseRun
 
 	brewUpdater, err := brew.BrewUpdater{}.New(*initConfiguration)
-	brewUpdater.Config.Enabled = err == nil
+	if err != nil {
+		brewUpdater.Config.Enabled = false
+		slog.Debug("Brew driver failed to initialize", slog.Any("error", err))
+	}
 
 	flatpakUpdater, err := flatpak.FlatpakUpdater{}.New(*initConfiguration)
-	flatpakUpdater.Config.Enabled = err == nil
+	if err != nil {
+		flatpakUpdater.Config.Enabled = false
+		slog.Debug("Flatpak driver failed to initialize", slog.Any("error", err))
+	}
 	flatpakUpdater.SetUsers(users)
 
 	distroboxUpdater, err := distrobox.DistroboxUpdater{}.New(*initConfiguration)
-	distroboxUpdater.Config.Enabled = err == nil
+	if err != nil {
+		distroboxUpdater.Config.Enabled = false
+		slog.Debug("Distrobox driver failed to initialize", slog.Any("error", err))
+	}
 	distroboxUpdater.SetUsers(users)
 
 	mainSystemDriver, mainSystemDriverConfig, _, _ := system.InitializeSystemDriver(*initConfiguration)

--- a/drv/brew/brew.go
+++ b/drv/brew/brew.go
@@ -99,7 +99,6 @@ func (up BrewUpdater) New(config UpdaterInitConfiguration) (BrewUpdater, error) 
 
 	uid, err := up.GetBrewUID()
 	if err != nil {
-		up.Config.Enabled = false
 		return up, err
 	}
 	up.BaseUser = uid

--- a/drv/brew/brew.go
+++ b/drv/brew/brew.go
@@ -99,6 +99,7 @@ func (up BrewUpdater) New(config UpdaterInitConfiguration) (BrewUpdater, error) 
 
 	uid, err := up.GetBrewUID()
 	if err != nil {
+		up.Config.Enabled = false
 		return up, err
 	}
 	up.BaseUser = uid

--- a/drv/brew/brew_test.go
+++ b/drv/brew/brew_test.go
@@ -10,7 +10,7 @@ import (
 
 func InitBaseConfig() brew.BrewUpdater {
 	var initConfiguration = generic.UpdaterInitConfiguration{
-		DryRun:      false,
+		DryRun:      true,
 		Ci:          false,
 		Verbose:     false,
 		Environment: nil,

--- a/drv/distrobox/distrobox.go
+++ b/drv/distrobox/distrobox.go
@@ -2,6 +2,7 @@ package distrobox
 
 import (
 	"log/slog"
+	"os"
 	"strings"
 
 	. "github.com/ublue-os/uupd/drv/generic"
@@ -44,6 +45,14 @@ func (up DistroboxUpdater) New(config UpdaterInitConfiguration) (DistroboxUpdate
 	up.Tracker = nil
 
 	up.binaryPath = EnvOrFallback(up.Config.Environment, "UUPD_DISTROBOX_BINARY", "/usr/bin/distrobox")
+
+	inf, err := os.Stat(up.binaryPath)
+	if err != nil {
+		up.Config.Enabled = false
+		return up, err
+	}
+	// check if file is executable using bitmask
+	up.Config.Enabled = inf.Mode()&0111 != 0
 
 	return up, nil
 }

--- a/drv/distrobox/distrobox.go
+++ b/drv/distrobox/distrobox.go
@@ -73,18 +73,18 @@ func (up DistroboxUpdater) Update() (*[]CommandOutput, error) {
 	var finalOutput = []CommandOutput{}
 
 	if up.Config.DryRun {
-		percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: up.Config.Description})
+		up.Tracker.ReportStatusChange(up.Config.Title, up.Config.Description)
 		up.Tracker.IncrementSection(nil)
 
 		var err error = nil
 		for _, user := range up.users {
 			up.Tracker.IncrementSection(err)
-			percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: *up.Config.UserDescription + " " + user.Name})
+			up.Tracker.ReportStatusChange(up.Config.Title, *up.Config.UserDescription+" "+user.Name)
 		}
 		return &finalOutput, nil
 	}
 
-	percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: up.Config.Description})
+	up.Tracker.ReportStatusChange(up.Config.Title, up.Config.Description)
 	cli := []string{up.binaryPath, "upgrade", "-a"}
 	out, err := session.RunUID(up.Config.Logger, slog.LevelDebug, 0, cli, nil)
 	tmpout := CommandOutput{}.New(out, err)
@@ -97,7 +97,7 @@ func (up DistroboxUpdater) Update() (*[]CommandOutput, error) {
 	for _, user := range up.users {
 		up.Tracker.IncrementSection(err)
 		context := *up.Config.UserDescription + " " + user.Name
-		percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: *up.Config.UserDescription + " " + user.Name})
+		up.Tracker.ReportStatusChange(up.Config.Title, *up.Config.UserDescription+" "+user.Name)
 		cli := []string{up.binaryPath, "upgrade", "-a"}
 		out, err := session.RunUID(up.Config.Logger, slog.LevelDebug, user.UID, cli, nil)
 		tmpout = CommandOutput{}.New(out, err)

--- a/drv/distrobox/distrobox.go
+++ b/drv/distrobox/distrobox.go
@@ -46,6 +46,10 @@ func (up DistroboxUpdater) New(config UpdaterInitConfiguration) (DistroboxUpdate
 
 	up.binaryPath = EnvOrFallback(up.Config.Environment, "UUPD_DISTROBOX_BINARY", "/usr/bin/distrobox")
 
+	if up.Config.DryRun {
+		return up, nil
+	}
+
 	inf, err := os.Stat(up.binaryPath)
 	if err != nil {
 		up.Config.Enabled = false

--- a/drv/distrobox/distrobox.go
+++ b/drv/distrobox/distrobox.go
@@ -52,7 +52,6 @@ func (up DistroboxUpdater) New(config UpdaterInitConfiguration) (DistroboxUpdate
 
 	inf, err := os.Stat(up.binaryPath)
 	if err != nil {
-		up.Config.Enabled = false
 		return up, err
 	}
 	// check if file is executable using bitmask

--- a/drv/distrobox/distrobox_test.go
+++ b/drv/distrobox/distrobox_test.go
@@ -12,7 +12,7 @@ import (
 
 func InitBaseConfig() distrobox.DistroboxUpdater {
 	var initConfiguration = generic.UpdaterInitConfiguration{
-		DryRun:      false,
+		DryRun:      true,
 		Ci:          false,
 		Verbose:     false,
 		Environment: nil,

--- a/drv/flatpak/flatpak.go
+++ b/drv/flatpak/flatpak.go
@@ -62,18 +62,18 @@ func (up FlatpakUpdater) Update() (*[]CommandOutput, error) {
 	var finalOutput = []CommandOutput{}
 
 	if up.Config.DryRun {
-		percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: up.Config.Description})
+		up.Tracker.ReportStatusChange(up.Config.Title, up.Config.Description)
 		up.Tracker.IncrementSection(nil)
 
 		var err error = nil
 		for _, user := range up.users {
 			up.Tracker.IncrementSection(err)
-			percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: *up.Config.UserDescription + " " + user.Name})
+			up.Tracker.ReportStatusChange(up.Config.Title, *up.Config.UserDescription+" "+user.Name)
 		}
 		return &finalOutput, nil
 	}
 
-	percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: up.Config.Description})
+	up.Tracker.ReportStatusChange(up.Config.Title, up.Config.Description)
 	cli := []string{up.binaryPath, "update", "-y", "--noninteractive"}
 	flatpakCmd := exec.Command(cli[0], cli[1:]...)
 	out, err := session.RunLog(up.Config.Logger, slog.LevelDebug, flatpakCmd)
@@ -87,7 +87,7 @@ func (up FlatpakUpdater) Update() (*[]CommandOutput, error) {
 	for _, user := range up.users {
 		up.Tracker.IncrementSection(err)
 		context := *up.Config.UserDescription + " " + user.Name
-		percent.ReportStatusChange(up.Tracker, percent.TrackerMessage{Title: up.Config.Title, Description: context})
+		up.Tracker.ReportStatusChange(up.Config.Title, context)
 		cli := []string{up.binaryPath, "update", "-y"}
 		out, err := session.RunUID(up.Config.Logger, slog.LevelDebug, user.UID, cli, nil)
 		tmpout = CommandOutput{}.New(out, err)

--- a/drv/flatpak/flatpak_test.go
+++ b/drv/flatpak/flatpak_test.go
@@ -12,7 +12,7 @@ import (
 
 func InitBaseConfig() flatpak.FlatpakUpdater {
 	var initConfiguration = generic.UpdaterInitConfiguration{
-		DryRun:      false,
+		DryRun:      true,
 		Ci:          false,
 		Verbose:     false,
 		Environment: nil,

--- a/drv/rpmostree/rpmostree_test.go
+++ b/drv/rpmostree/rpmostree_test.go
@@ -10,7 +10,7 @@ import (
 
 func InitBaseConfig() rpmostree.RpmOstreeUpdater {
 	var initConfiguration = generic.UpdaterInitConfiguration{
-		DryRun:      false,
+		DryRun:      true,
 		Ci:          false,
 		Verbose:     false,
 		Environment: nil,

--- a/drv/system/system_test.go
+++ b/drv/system/system_test.go
@@ -10,7 +10,7 @@ import (
 
 func InitBaseConfig() system.SystemUpdater {
 	var initConfiguration = generic.UpdaterInitConfiguration{
-		DryRun:      false,
+		DryRun:      true,
 		Ci:          false,
 		Verbose:     false,
 		Environment: nil,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/shirou/gopsutil/v4 v4.24.10
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/term v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -19,5 +20,5 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,10 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
-golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/percent/incrementer.go
+++ b/pkg/percent/incrementer.go
@@ -3,6 +3,7 @@ package percent
 type Incrementer struct {
 	DoneIncrements int
 	MaxIncrements  int
+	OscEnabled     bool
 }
 
 func (it *Incrementer) IncrementSection(err error) {

--- a/pkg/percent/progressmanager.go
+++ b/pkg/percent/progressmanager.go
@@ -1,18 +1,20 @@
 package percent
 
 import (
+	"fmt"
 	"log/slog"
+	"math"
 )
 
-type TrackerMessage struct {
-	Title       string
-	Description string
-}
+func (tracker Incrementer) ReportStatusChange(title string, description string) {
+	if tracker.OscEnabled {
+		percentage := math.Round((float64(tracker.CurrentStep()) / float64(tracker.MaxIncrements)) * 100)
+		fmt.Printf("\033]9;4;1;%d\a", int(percentage))
+	}
 
-func ReportStatusChange(tracker *Incrementer, message TrackerMessage) {
 	slog.Info("Updating",
-		slog.String("title", message.Title),
-		slog.String("description", message.Description),
+		slog.String("title", title),
+		slog.String("description", description),
 		slog.Int("progress", tracker.CurrentStep()),
 		slog.Int("total", tracker.MaxIncrements),
 	)

--- a/uupd.spec
+++ b/uupd.spec
@@ -1,5 +1,7 @@
+%define uupd_version %(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo unknown)
+
 Name:           uupd
-Version:        1.0
+Version:        %{uupd_version}
 Release:        1%{?dist}
 Summary:       Centralized update service/checker made for Universal Blue
 Vendor:        ublue-os

--- a/uupd.spec
+++ b/uupd.spec
@@ -1,7 +1,5 @@
-%define uupd_version %(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo unknown)
-
 Name:           uupd
-Version:        %{uupd_version}
+Version:        0.5.1
 Release:        1%{?dist}
 Summary:       Centralized update service/checker made for Universal Blue
 Vendor:        ublue-os


### PR DESCRIPTION
This PR makes the distrobox module disabled when the bin path isn't executable. I didn't make the changes to the other drivers because that would kinda be like "silently failing." If flatpak or bootc fail to update the user should probably know and the program should send an error.

This also makes it so there's proper versioning within the SPEC so it doesn't get built as "version 1.0" constantly