### PR TITLE
fix: rpm-ostree updater segfault, error reporting

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -111,7 +111,7 @@ func Update(cmd *cobra.Command, args []string) {
 
 	mainSystemDriver, mainSystemDriverConfig, _, _ := system.InitializeSystemDriver(*initConfiguration)
 
-	enableUpd, err := false, nil
+	enableUpd, err := true, nil
 	// if there's no force flag, check for updates
 	if !force {
 		enableUpd, err = mainSystemDriver.Check()

--- a/drv/rpmostree/rpmostree.go
+++ b/drv/rpmostree/rpmostree.go
@@ -57,10 +57,13 @@ func (up RpmOstreeUpdater) Outdated() (bool, error) {
 
 func (up RpmOstreeUpdater) Update() (*[]CommandOutput, error) {
 	var finalOutput = []CommandOutput{}
-	var cmd *exec.Cmd
 	binaryPath := up.BinaryPath
+
 	cli := []string{binaryPath, "upgrade"}
+	up.Config.Logger.Debug("Executing update", slog.Any("cli", cli))
+	cmd := exec.Command(cli[0], cli[1:]...)
 	out, err := session.RunLog(up.Config.Logger, slog.LevelDebug, cmd)
+
 	tmpout := CommandOutput{}.New(out, err)
 	tmpout.Cli = cli
 	tmpout.Failure = err != nil

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -27,20 +27,20 @@ func RunLog(logger *slog.Logger, level slog.Level, command *exec.Cmd) ([]byte, e
 	stdout, _ := command.StdoutPipe()
 	stderr, _ := command.StderrPipe()
 	multiReader := io.MultiReader(stdout, stderr)
-	actuallogger := slog.Default()
+	actualLogger := slog.Default()
 	err := command.Start()
 	if err != nil {
-		actuallogger.Warn("Error occoured starting external command", slog.Any("error", err))
+		actualLogger.Warn("Error occurred starting external command", slog.Any("error", err))
 		return []byte{}, err
 	}
 	scanner := bufio.NewScanner(multiReader)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		actuallogger.Log(context.TODO(), level, scanner.Text())
+		actualLogger.Log(context.TODO(), level, scanner.Text())
 	}
 	err = command.Wait()
 	if err != nil {
-		actuallogger.Warn("Error occoured while waiting for external command", slog.Any("error", err))
+		actualLogger.Warn("Error occurred while waiting for external command", slog.Any("error", err))
 		return []byte{}, err
 	}
 


### PR DESCRIPTION
This PR makes `RunLog` return out the correct error and fixes a segfault in the `rpm-ostree` updater