### PR TITLE
fix: run rpm-ostree when bootc fails, loosen SELinux context in service

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -168,10 +168,10 @@ func Update(cmd *cobra.Command, args []string) {
 		if err != nil {
 			slog.Debug("bootc update failed, falling back to rpm-ostree updater")
 
-			rpmostree_updater, rpmostree_err := rpmostree.RpmOstreeUpdater{}.New(*initConfiguration)
-			rpmostree_out, rpmostree_err := rpmostree_updater.Update()
-			err = rpmostree_err
-			out = rpmostree_out
+			rpmostreeUpdater, rpmostreeErr := rpmostree.RpmOstreeUpdater{}.New(*initConfiguration)
+			rpmostreeOut, rpmostreeErr := rpmostreeUpdater.Update()
+			err = rpmostreeErr
+			out = rpmostreeOut
 		}
 		outputs = append(outputs, *out...)
 		tracker.IncrementSection(err)

--- a/drv/system/system.go
+++ b/drv/system/system.go
@@ -162,5 +162,4 @@ func InitializeSystemDriver(initConfiguration UpdaterInitConfiguration) (SystemU
 	}
 	mainSystemDriver = rpmOstreeUpdater
 	return mainSystemDriver, rpmOstreeUpdater.Config, isBootc, err
-
 }

--- a/uupd.service
+++ b/uupd.service
@@ -4,3 +4,4 @@ Description=Universal Blue Update Oneshot Service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/uupd --log-level debug --json --hw-check
+SELinuxContext=system_u:unconfined_r:unconfined_t:s0

--- a/uupd.spec
+++ b/uupd.spec
@@ -1,5 +1,5 @@
 Name:           uupd
-Version:        1.0.2
+Version:        1.0.3
 Release:        1%{?dist}
 Summary:       Centralized update service/checker made for Universal Blue
 Vendor:        ublue-os


### PR DESCRIPTION
Needs some sanity checking to make sure it all works and actually fixes selinux issues but should mostly be good