### PR TITLE
chore: entirely remove the "updates failed for blah" popup

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -241,7 +241,6 @@ func Update(cmd *cobra.Command, args []string) {
 		for _, output := range failures {
 			slog.Info(output.Context, slog.Any("output", output))
 		}
-		session.Notify(users, "Some System Updates Failed", fmt.Sprintf("Systems Failed: %s", strings.Join(contexts, ", ")), "critical")
 
 		return
 	}


### PR DESCRIPTION

I personally just find this thing annoying, dunno if we need it to show a notification all the time