### PR TITLE
feat: Add check for metered connections

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,7 @@ func init() {
 	isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 	rootCmd.Flags().Bool("disable-progress", !isTerminal, "Disable the GUI progress indicator, automatically disabled when loglevel is debug or in JSON")
 	rootCmd.Flags().Bool("apply", false, "Reboot if there's an update to the image")
+	rootCmd.Flags().BoolP("ignore-metered-connection", "m", false, "Run update on metered connection")
 	rootCmd.PersistentFlags().BoolVar(&fLogJson, "json", false, "Print logs as json (used for testing)")
 	rootCmd.PersistentFlags().StringVar(&fLogFile, "log-file", "-", "File where user-facing logs will be written to")
 	rootCmd.PersistentFlags().StringVar(&fLogLevel, "log-level", "info", "Log level for user-facing logs")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -21,6 +21,22 @@ import (
 )
 
 func Update(cmd *cobra.Command, args []string) {
+
+	meteredIgnore, err := cmd.Flags().GetBool("ignore-metered-connection")
+	if err != nil {
+		slog.Error("Failed to get ignore-metered-connection flag", "error", err)
+		return
+	}
+
+	meteredConn, err := session.CheckMeteredConn()
+	if err != nil {
+		slog.Error("There was an error getting Metered Network status", slog.Any("error", err))
+	}
+	if meteredConn == true && meteredIgnore == false {
+		slog.Error("Metered Network Connection detected. Update will be cancelled. To update on Metered Connections, run with --ignore-metered-connection flag")
+		return
+	}
+
 	lockfile, err := filelock.OpenLockfile(filelock.GetDefaultLockfile())
 	if err != nil {
 		slog.Error("Failed creating and opening lockfile. Is uupd already running?", slog.Any("error", err))

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -119,3 +119,32 @@ func Notify(users []User, summary string, body string, urgency string) error {
 	}
 	return nil
 }
+
+func CheckMeteredConn() (bool, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to system bus: %v", err)
+	}
+	bo := conn.Object("org.freedesktop.NetworkManager", "/org/freedesktop/NetworkManager")
+	variant, err := bo.GetProperty("org.freedesktop.NetworkManager.Metered")
+	if err != nil {
+		return false, fmt.Errorf("There was an error connecting to the NetworkManager interface")
+	}
+	var status bool
+	switch variant.Value() {
+	case uint32(0): //NM_METERED_UNKNOWN
+		status = false
+	case uint32(1): //NM_METERED_YES
+		status = true
+	case uint32(2): //NM_METERED_NO
+		status = false
+	case uint32(3): //NM_METERED_GUESS_YES
+		status = true
+	case uint32(4): //NM_METERED_GUESS_NO
+		status = false
+	default:
+		status = false
+	}
+
+	return status, err
+}


### PR DESCRIPTION
When running an update, `uupd` does not check if the user is currently on a metered connection (e.g.: routing cellular network). In combination with automatic background updates, this may result in unwanted charges being applied.

This feature adds a check for metered connections by querying the NetworkManager dbus interface. If the connection is metered, the update will be aborted (checking for updates still happens). The user can manually override this behaviour by supplying the `--ignore-metered-connection` flag to `uupd`.