### PR TITLE
fix: auto retry service

### DIFF
--- a/uupd.service
+++ b/uupd.service
@@ -8,5 +8,13 @@ Type=oneshot
 #Environment="UUPD_NETWORK_MAX_BYTES=500000"
 #Environment="UUPD_MEMORY_MAX_PERCENT=90"
 #Environment="UUPD_CPU_MAX_LOAD_PERCENT=50"
+
+# DO NOT CHANGE ANYTHING BELOW UNLESS YOU KNOW WHAT YOU ARE DOING
 ExecStart=/usr/bin/uupd --log-level debug --json --hw-check
+# Restart on failure for edge cases like waking from suspend and wifi not connecting immediately
+Restart=on-failure
+RestartSec=60s
+StartLimitIntervalSec=600
+StartLimitBurst=3
+# Set SELinux context unconfined because bootc requires some special perms for relabeling (install_t????)
 SELinuxContext=system_u:unconfined_r:unconfined_t:s0


### PR DESCRIPTION
This should fix some issues when waking from suspend or maybe edge cases where the hardware checks are ran at a slightly inconvenient time.
Attempts to solve: https://github.com/ublue-os/uupd/issues/85