### PR TITLE
tweak uupd-manual.service, fix trailing comma

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,7 +19,7 @@
             "disable": false
         },
         "system": {
-            "disable": false,
+            "disable": false
         }
     }
 }

--- a/uupd-manual.service
+++ b/uupd-manual.service
@@ -12,7 +12,7 @@ Type=oneshot
 #Environment="UUPD_CPU_MAX_LOAD_PERCENT=50"
 
 # DO NOT CHANGE ANYTHING BELOW UNLESS YOU KNOW WHAT YOU ARE DOING
-ExecStart=/usr/bin/uupd --hw-check=false
+ExecStart=/usr/bin/uupd --hw-check=false --json --log-level debug
 # Restart on failure for edge cases like waking from suspend and wifi not connecting immediately
 Restart=on-failure
 RestartSec=60s


### PR DESCRIPTION
- adds `--json --log-level debug` to uupd-manual.service
- removes the trailing comma in config.json