### PR TITLE
Update uupd.service to disable on metered connections

### DIFF
--- a/uupd.service
+++ b/uupd.service
@@ -2,9 +2,14 @@
 Description=Universal Blue Update Oneshot Service
 StartLimitBurst=3
 StartLimitIntervalSec=600
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
+# Skips update when on a metered connection
+ExecCondition=/bin/bash -c '! nmcli -g GENERAL.METERED device show | grep -qi "^yes"'
+
 # DO NOT CHANGE ANYTHING BELOW UNLESS YOU KNOW WHAT YOU ARE DOING
 ExecStart=/usr/bin/uupd --log-level=debug --json
 # Restart on failure for edge cases like waking from suspend and wifi not connecting immediately


### PR DESCRIPTION
This will lower data consumption on metered networks. If a user configures their network as a metered connection, they are likely to be conserving data. They may do this for any number of reasons. My personal reason is that I do this for my mobile hot spot. I have a monthly quota of 20 GB, so I need to be careful about data consumption whilst tethered to my phone. Since this service is automatic, it will sometimes drain my data as updates can be quite large at times. This is a small but useful QOL update for users of restrictive internet.

Users who do not mark the network as "metered" will be completely unaffected by this change.

This will match the auto-update's mechanisms to that of Bazaar, which is a default app on most UBlue systems, which also does not auto-update on metered network, making the system update component more consistent with other included apps.

Also, I made sure to require network online just for an additional guarantee that the service has its dependencies met at runtime.

This functionality is actually the expected functionality because look at how the network manager GUI presents the metered network option:
<img width="649" height="192" alt="image" src="https://github.com/user-attachments/assets/70f38eac-8f3c-4060-8445-51fff1ac71cc" />