### PR TITLE
fix: enforce brew no ask mode for upgrade

### DIFF
--- a/drv/brew/brew.go
+++ b/drv/brew/brew.go
@@ -60,7 +60,7 @@ func (up BrewUpdater) Update(_tracker *percent.Incrementer) (*[]CommandOutput, e
 		return &final_output, err
 	}
 
-	cli = []string{up.BrewPath, "upgrade"}
+	cli = []string{up.BrewPath, "upgrade", "-y"}
 	out, err = session.RunUID(up.Config.Logger, slog.LevelDebug, up.BaseUser, cli, up.Config.Environment)
 	tmpout = CommandOutput{}.New(out, err)
 	tmpout.Context = "Brew Upgrade"


### PR DESCRIPTION
Since Homebrew's [6.0.0 release](https://brew.sh/2026/06/11/homebrew-6.0.0/) it started to ask whenever the user wants to update their Brew packages unless `HOMEBREW_NO_ASK` environment variable has been set to `1`, which is not ideal for noninteractive actions, so this PR enforces no ask mode by running `brew upgrade -y` like how it's done for Flatpak for example.